### PR TITLE
Enable STP image integration in Excel generation

### DIFF
--- a/app/api/process-xlsx/route.ts
+++ b/app/api/process-xlsx/route.ts
@@ -5,13 +5,18 @@ import { promises as fs } from "fs";
 import path from "path";
 import os from "os";
 import ExcelJS from "exceljs";
+import JSZip from "jszip";
 import { GoogleGenAI } from "@google/genai";
 
 // ---- ENV ----
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const PYTHON_RENDERER_URL = process.env.PYTHON_RENDERER_URL;
 
 if (!GEMINI_API_KEY) {
   console.error("Required environment variable missing: GEMINI_API_KEY");
+}
+if (!PYTHON_RENDERER_URL) {
+  console.error("Required environment variable missing: PYTHON_RENDERER_URL");
 }
 
 // ---- TMP PATHS ----
@@ -236,8 +241,32 @@ function extractStructures(txt: string): [string, string] {
   return [clean(arrMatch[1]), clean(objMatch[1])];
 }
 
+// ---- STP Image Rendering ----
+async function renderStpFiles(files: { path: string; name: string }[]): Promise<Record<string, Buffer>> {
+  const map: Record<string, Buffer> = {};
+  if (!PYTHON_RENDERER_URL) return map;
+  for (const f of files) {
+    try {
+      const buf = await fs.readFile(f.path);
+      const fd = new FormData();
+      fd.append("file", new Blob([buf]), f.name);
+      const res = await fetch(PYTHON_RENDERER_URL, { method: "POST", body: fd });
+      if (!res.ok) continue;
+      const zipBuf = Buffer.from(await res.arrayBuffer());
+      const zip = await JSZip.loadAsync(zipBuf);
+      const imgName = Object.keys(zip.files).find(n => !zip.files[n].dir && /\.(png|jpe?g)$/i.test(n));
+      if (imgName) {
+        map[f.name] = await zip.files[imgName].async("nodebuffer");
+      }
+    } catch (e) {
+      console.error("Failed to render STP", f.name, e);
+    }
+  }
+  return map;
+}
+
 // ---- Excel Builders ----
-async function buildProductionOrder(layout: any[]): Promise<Buffer> {
+async function buildProductionOrder(layout: any[], images: Record<string, Buffer>): Promise<Buffer> {
   const wb = new ExcelJS.Workbook();
   const ws = wb.addWorksheet("生产单");
   ws.columns = ["序号", "产品图片", "产品编号", "产品名称", "规格", "材料", "数量", "加工方式", "工艺要求"].map(h => ({
@@ -258,6 +287,15 @@ async function buildProductionOrder(layout: any[]): Promise<Buffer> {
       case "main_table_header_row":
       case "main_table_data_row":
         row.values = item.headers || item.data;
+        if (item.type === "main_table_data_row" && item.data[1]) {
+          const key = item.data[1];
+          const img = images[key];
+          if (img) {
+            const id = wb.addImage({ buffer: img, extension: 'png' });
+            ws.addImage(id, `B${row.number}:B${row.number}`);
+            row.height = Math.max(row.height || 18, 80);
+          }
+        }
         break;
     }
     row.height = item.height;
@@ -265,7 +303,7 @@ async function buildProductionOrder(layout: any[]): Promise<Buffer> {
   return wb.xlsx.writeBuffer();
 }
 
-async function buildQuotation(q: any): Promise<Buffer> {
+async function buildQuotation(q: any, images: Record<string, Buffer>): Promise<Buffer> {
     const workbook = new ExcelJS.Workbook();
     const ws = workbook.addWorksheet("报价单");
   
@@ -304,17 +342,24 @@ async function buildQuotation(q: any): Promise<Buffer> {
     // Products Data Rows
     q.products.forEach(product => {
       const row = ws.addRow([
-        product["序号"], 
-        product["零件图片"], 
-        product["零件名"], 
-        product["表面"], 
+        product["序号"],
+        product["零件图片"],
+        product["零件名"],
+        product["表面"],
         product["材质"],
-        product["数量"], 
+        product["数量"],
         "",
         "",
         product["备注"]
       ]);
-      row.height = 18;
+      const key = product["零件图片"] || product["零件名"];
+      if (images[key]) {
+        const id = workbook.addImage({ buffer: images[key], extension: 'png' });
+        ws.addImage(id, `B${row.number}:B${row.number}`);
+        row.height = Math.max(row.height, 80);
+      } else {
+        row.height = 18;
+      }
     });
   
     // Total Row
@@ -371,6 +416,7 @@ export async function POST(req: Request) {
 
   const fd = await req.formData();
   const file = fd.get("file") as File | null;
+  const stpUploads = fd.getAll("stpFiles") as File[];
   if (!file || !file.name.endsWith(".xlsx"))
     return NextResponse.json({ error: "Invalid file. Upload '.xlsx'." }, { status: 400 });
 
@@ -378,6 +424,12 @@ export async function POST(req: Request) {
   const upPath = path.join(UPLOAD_DIR, slug, file.name);
   await fs.mkdir(path.dirname(upPath), { recursive: true });
   await fs.writeFile(upPath, Buffer.from(await file.arrayBuffer()));
+  const stpInfo: { path: string; name: string }[] = [];
+  for (const sf of stpUploads) {
+    const p = path.join(UPLOAD_DIR, slug, sf.name);
+    await fs.writeFile(p, Buffer.from(await sf.arrayBuffer()));
+    stpInfo.push({ path: p, name: sf.name });
+  }
 
   try {
     // Parse Excel directly to text
@@ -394,8 +446,10 @@ export async function POST(req: Request) {
     const layout = JSON.parse(arrJS);
     const quotation = JSON.parse(objJS);
 
-    const prodBuf = await buildProductionOrder(layout);
-    const quoteBuf = await buildQuotation(quotation);
+    const imageMap = await renderStpFiles(stpInfo);
+
+    const prodBuf = await buildProductionOrder(layout, imageMap);
+    const quoteBuf = await buildQuotation(quotation, imageMap);
 
     return NextResponse.json({
       productionOrderBase64: Buffer.from(prodBuf).toString("base64"),

--- a/components/excel-viewer.tsx
+++ b/components/excel-viewer.tsx
@@ -6,10 +6,13 @@ import { useState, useEffect } from "react";
 import * as XLSX from "xlsx";
 import { Button } from "@/components/ui/button";
 
-interface ExcelViewerProps { file: File }
+interface ExcelViewerProps {
+  file: File;
+  stpFiles?: File[];
+}
 interface SheetData { name: string; data: any[][]; headers: string[] }
 
-export function ExcelViewer({ file }: ExcelViewerProps) {
+export function ExcelViewer({ file, stpFiles = [] }: ExcelViewerProps) {
   const [sheets, setSheets] = useState<SheetData[]>([]);
   const [active, setActive] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -63,6 +66,7 @@ export function ExcelViewer({ file }: ExcelViewerProps) {
     setRaw(null);
     const fd = new FormData();
     fd.append("file", file);
+    stpFiles.forEach((f) => fd.append("stpFiles", f, f.name));
     const res = await fetch("/api/process-xlsx", { method: "POST", body: fd });
     if (!res.ok) {
       alert("服务器处理失败 – " + (await res.text()));

--- a/file-viewer.tsx
+++ b/file-viewer.tsx
@@ -135,7 +135,7 @@ export default function FileViewer() {
                 <h4 className="text-lg font-semibold mb-4 text-gray-800 dark:text-gray-200">
                   Specification Sheet: <span className="font-normal text-green-700 dark:text-green-400">{primaryExcelFile.name}</span>
                 </h4>
-                <ExcelViewer file={primaryExcelFile} />
+                <ExcelViewer file={primaryExcelFile} stpFiles={stpFileItems.map(i => i.file)} />
               </div>
             )}
             {!primaryExcelFile && allExcelFilesCount > 0 && (


### PR DESCRIPTION
## Summary
- let `ExcelViewer` send STP files to the backend
- update `FileViewer` to pass the STP uploads
- extend `process-xlsx` API to render STP files and embed images in output Excel files

## Testing
- `npm install` *(fails without skipping puppeteer download; retried with `PUPPETEER_SKIP_DOWNLOAD=true`)*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_683fa890f430832dbb35d2fcbc22f7a7